### PR TITLE
Add API service for league position query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,6 @@
 			<artifactId>springfox-swagger-ui</artifactId>
 			<version>2.9.2</version>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.4.RELEASE</version>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/kr/ac/ajou/LolCrawler/api/LolApiClient.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/api/LolApiClient.java
@@ -1,0 +1,28 @@
+package kr.ac.ajou.LolCrawler.api;
+
+import kr.ac.ajou.LolCrawler.domain.SummonerDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class LolApiClient {
+    private final String api_key = "RGAPI-090ffbc6-a810-4fab-b6e8-e7e7f0561b3e";
+    private final String summonersApiUrl = "https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/{summonerName}?api_key={api_key}";
+    private final String positionsApiUrl = "https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/{encryptedSummonerId}?api_key={api_key}";
+
+    @Autowired
+    RestTemplate restTemplate;
+
+    public String requestEncryptedSummonerId(String summonerName) {
+        SummonerDTO res = restTemplate.exchange(summonersApiUrl, HttpMethod.GET, null, SummonerDTO.class, summonerName, api_key)
+                .getBody();
+        return res.getId();
+    }
+
+    public String requestLeaugePosition(String encryptedSummonerId) {
+        return restTemplate.exchange(positionsApiUrl, HttpMethod.GET, null, String.class, encryptedSummonerId, api_key)
+                .getBody();
+    }
+}

--- a/src/main/java/kr/ac/ajou/LolCrawler/config/HttpConfig.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/config/HttpConfig.java
@@ -1,0 +1,14 @@
+package kr.ac.ajou.LolCrawler.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpConfig {
+    @Bean
+    public RestTemplate createRestTemplate() {
+        return new RestTemplate();
+    }
+}
+

--- a/src/main/java/kr/ac/ajou/LolCrawler/config/SwaggerConfig.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/config/SwaggerConfig.java
@@ -1,0 +1,49 @@
+package kr.ac.ajou.LolCrawler.config;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import static springfox.documentation.builders.PathSelectors.regex;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig implements WebMvcConfigurer {
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(this.apiInfo())
+                .select()
+                .paths(paths())
+                .build();
+    }
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addRedirectViewController("/", "/swagger-ui.html");
+    }
+
+    private Predicate paths() {
+        return Predicates.or(
+                regex("/.*"),
+                regex("/health"),
+                regex("/info")
+        );
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("Weather Crawler")
+                .version("1.0")
+                .build();
+    }
+}
+

--- a/src/main/java/kr/ac/ajou/LolCrawler/controller/LolController.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/controller/LolController.java
@@ -1,0 +1,19 @@
+package kr.ac.ajou.LolCrawler.controller;
+
+import kr.ac.ajou.LolCrawler.service.LolService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LolController {
+    @Autowired
+    LolService lolService;
+
+    @GetMapping("/league-position/{summonerName}")
+    public String getLeaguePosition(@PathVariable String summonerName) {
+        return lolService.getLeaguePosition(summonerName);
+    }
+
+}

--- a/src/main/java/kr/ac/ajou/LolCrawler/domain/SummonerDTO.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/domain/SummonerDTO.java
@@ -1,0 +1,8 @@
+package kr.ac.ajou.LolCrawler.domain;
+
+import lombok.Data;
+
+@Data
+public class SummonerDTO {
+    String id;
+}

--- a/src/main/java/kr/ac/ajou/LolCrawler/service/LolService.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/service/LolService.java
@@ -1,0 +1,20 @@
+package kr.ac.ajou.LolCrawler.service;
+
+import kr.ac.ajou.LolCrawler.api.LolApiClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class LolService {
+    @Autowired
+    LolApiClient lolApiClient;
+
+    public String getLeaguePosition(String summonerId) {
+        String encryptedId = lolApiClient.requestEncryptedSummonerId(summonerId);
+        log.info("Encrypted Summoner Id: {}", encryptedId);
+        return lolApiClient.requestLeaugePosition(encryptedId);
+    }
+
+}


### PR DESCRIPTION
![Screenshot from 2019-07-09 21-13-49](https://user-images.githubusercontent.com/32378542/60887162-9f1c5280-a28e-11e9-97ad-7933178f2df8.png)
/league-position/{summonerId}로 우선 GET 방식 기반의 API 생성했습니다.
Swagger 추가해 놓았으니 편리하게 확인하실 수 있을겁니다.
