### PR TITLE
Declare LeaguePosition Class in domain package and replace String type

### DIFF
--- a/src/main/java/kr/ac/ajou/LolCrawler/api/LolApiClient.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/api/LolApiClient.java
@@ -1,6 +1,8 @@
 package kr.ac.ajou.LolCrawler.api;
 
+import kr.ac.ajou.LolCrawler.domain.LeaguePosition;
 import kr.ac.ajou.LolCrawler.domain.SummonerDTO;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
@@ -8,7 +10,7 @@ import org.springframework.web.client.RestTemplate;
 
 @Service
 public class LolApiClient {
-    private final String api_key = "RGAPI-090ffbc6-a810-4fab-b6e8-e7e7f0561b3e";
+    private final String api_key = "RGAPI-156acf29-0820-441f-9435-42842b7b7584";
     private final String summonersApiUrl = "https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/{summonerName}?api_key={api_key}";
     private final String positionsApiUrl = "https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/{encryptedSummonerId}?api_key={api_key}";
 
@@ -21,8 +23,9 @@ public class LolApiClient {
         return res.getId();
     }
 
-    public String requestLeaugePosition(String encryptedSummonerId) {
-        return restTemplate.exchange(positionsApiUrl, HttpMethod.GET, null, String.class, encryptedSummonerId, api_key)
+    public LeaguePosition requestLeaugePosition(String encryptedSummonerId) {
+        LeaguePosition leaguePosition = restTemplate.exchange(positionsApiUrl, HttpMethod.GET, null, LeaguePosition.class, encryptedSummonerId, api_key)
                 .getBody();
+        return leaguePosition;
     }
 }

--- a/src/main/java/kr/ac/ajou/LolCrawler/api/LolApiClient.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/api/LolApiClient.java
@@ -1,12 +1,14 @@
 package kr.ac.ajou.LolCrawler.api;
 
-import kr.ac.ajou.LolCrawler.domain.LeaguePosition;
+import kr.ac.ajou.LolCrawler.domain.LeagueEntryDTO;
 import kr.ac.ajou.LolCrawler.domain.SummonerDTO;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+
+import java.util.Set;
 
 @Service
 public class LolApiClient {
@@ -23,9 +25,10 @@ public class LolApiClient {
         return res.getId();
     }
 
-    public LeaguePosition requestLeaugePosition(String encryptedSummonerId) {
-        LeaguePosition leaguePosition = restTemplate.exchange(positionsApiUrl, HttpMethod.GET, null, LeaguePosition.class, encryptedSummonerId, api_key)
-                .getBody();
+
+    public Set<LeagueEntryDTO> requestLeaugePosition(String encryptedSummonerId) {
+        Set<LeagueEntryDTO> leaguePosition = restTemplate.exchange(positionsApiUrl, HttpMethod.GET, null, Set.class, encryptedSummonerId, api_key)
+        .getBody();
         return leaguePosition;
     }
 }

--- a/src/main/java/kr/ac/ajou/LolCrawler/controller/LolController.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/controller/LolController.java
@@ -1,5 +1,6 @@
 package kr.ac.ajou.LolCrawler.controller;
 
+import kr.ac.ajou.LolCrawler.domain.LeaguePosition;
 import kr.ac.ajou.LolCrawler.service.LolService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,7 +13,7 @@ public class LolController {
     LolService lolService;
 
     @GetMapping("/league-position/{summonerName}")
-    public String getLeaguePosition(@PathVariable String summonerName) {
+    public LeaguePosition getLeaguePosition(@PathVariable String summonerName) {
         return lolService.getLeaguePosition(summonerName);
     }
 

--- a/src/main/java/kr/ac/ajou/LolCrawler/controller/LolController.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/controller/LolController.java
@@ -1,11 +1,13 @@
 package kr.ac.ajou.LolCrawler.controller;
 
-import kr.ac.ajou.LolCrawler.domain.LeaguePosition;
+import kr.ac.ajou.LolCrawler.domain.LeagueEntryDTO;
 import kr.ac.ajou.LolCrawler.service.LolService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Set;
 
 @RestController
 public class LolController {
@@ -13,7 +15,7 @@ public class LolController {
     LolService lolService;
 
     @GetMapping("/league-position/{summonerName}")
-    public LeaguePosition getLeaguePosition(@PathVariable String summonerName) {
+    public Set<LeagueEntryDTO> getLeaguePosition(@PathVariable String summonerName) {
         return lolService.getLeaguePosition(summonerName);
     }
 

--- a/src/main/java/kr/ac/ajou/LolCrawler/domain/LeagueEntryDTO.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/domain/LeagueEntryDTO.java
@@ -2,12 +2,12 @@ package kr.ac.ajou.LolCrawler.domain;
 
 import lombok.Data;
 
+
 @Data
-public class LeaguePosition {
+public class LeagueEntryDTO{
     private String queueType;
     private String summonerName;
     private boolean hotStreak;
-    private MiniSeriesDTO miniSeriesDTO;
     private int wins;
     private boolean veteran;
     private int losses;
@@ -19,12 +19,6 @@ public class LeaguePosition {
     private String summonerId;
     private int leaguePoints;
 
-    @Data
-    public static class MiniSeriesDTO{
-        private String progress;
-        private int losses;
-        private int target;
-        private int wins;
-    }
 
 }
+

--- a/src/main/java/kr/ac/ajou/LolCrawler/domain/LeaguePosition.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/domain/LeaguePosition.java
@@ -1,0 +1,30 @@
+package kr.ac.ajou.LolCrawler.domain;
+
+import lombok.Data;
+
+@Data
+public class LeaguePosition {
+    private String queueType;
+    private String summonerName;
+    private boolean hotStreak;
+    private MiniSeriesDTO miniSeriesDTO;
+    private int wins;
+    private boolean veteran;
+    private int losses;
+    private String rank;
+    private String leagueId;
+    private boolean inactive;
+    private boolean freshBlood;
+    private String tier;
+    private String summonerId;
+    private int leaguePoints;
+
+    @Data
+    public static class MiniSeriesDTO{
+        private String progress;
+        private int losses;
+        private int target;
+        private int wins;
+    }
+
+}

--- a/src/main/java/kr/ac/ajou/LolCrawler/service/LolService.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/service/LolService.java
@@ -1,6 +1,7 @@
 package kr.ac.ajou.LolCrawler.service;
 
 import kr.ac.ajou.LolCrawler.api.LolApiClient;
+import kr.ac.ajou.LolCrawler.domain.LeaguePosition;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -11,7 +12,7 @@ public class LolService {
     @Autowired
     LolApiClient lolApiClient;
 
-    public String getLeaguePosition(String summonerId) {
+    public LeaguePosition getLeaguePosition(String summonerId) {
         String encryptedId = lolApiClient.requestEncryptedSummonerId(summonerId);
         log.info("Encrypted Summoner Id: {}", encryptedId);
         return lolApiClient.requestLeaugePosition(encryptedId);

--- a/src/main/java/kr/ac/ajou/LolCrawler/service/LolService.java
+++ b/src/main/java/kr/ac/ajou/LolCrawler/service/LolService.java
@@ -1,10 +1,14 @@
 package kr.ac.ajou.LolCrawler.service;
 
 import kr.ac.ajou.LolCrawler.api.LolApiClient;
-import kr.ac.ajou.LolCrawler.domain.LeaguePosition;
+import kr.ac.ajou.LolCrawler.domain.LeagueEntryDTO;
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+
+import java.util.Set;
 
 @Service
 @Slf4j
@@ -12,7 +16,7 @@ public class LolService {
     @Autowired
     LolApiClient lolApiClient;
 
-    public LeaguePosition getLeaguePosition(String summonerId) {
+    public Set<LeagueEntryDTO> getLeaguePosition(String summonerId) {
         String encryptedId = lolApiClient.requestEncryptedSummonerId(summonerId);
         log.info("Encrypted Summoner Id: {}", encryptedId);
         return lolApiClient.requestLeaugePosition(encryptedId);


### PR DESCRIPTION
Domain package에 LeaguePosition Class를 추가하고 String type으로 return 하는  requestLeaugePosition, getLeaguePosition함수들을 LeaguePosition으로 바꿨습니다. 

일단 추가 하긴 했는데,  LeaguePosition에 body 내용이 제대로 들어가는 걸 어떻게 확인해야 할지 잘 모르겠습니다. 피드백 부탁드립니다.

//////////////////////
7/11 5:00 AM 수정완료

![200](https://user-images.githubusercontent.com/50870720/61003185-4d62ed80-a39e-11e9-9b30-fce8647efc5b.PNG)

LeaguePosition class 이름을 LeagueEntryDTO로 바꾸고 내용을 수정했습니다. 
Response body의 형식 차이가 문제였던것 같습니다. Set.class를 이용하니까 잘 작동하네요.
어쨌든 Domain에 class 정의하는 부분은 완료했습니다! 
